### PR TITLE
Updated to create CFTs for Marketplace listings

### DIFF
--- a/CloudFormation/generate_qcft.py
+++ b/CloudFormation/generate_qcft.py
@@ -174,7 +174,7 @@ def add_nodes(t, nodes, prefix):
     t.add_output(Output(
         "InstanceId",
         Description="Copy and paste this instance ID into the QF2 Cluster Creation Screen.",
-        Value=Ref(prefix + "Qumulo1"),
+        Value=Ref(prefix + "Node1"),
     ))
 
 # create_qumulo_cft() takes a count of nodes to create, a prefix for node names, and an AMI ID.
@@ -213,8 +213,8 @@ def write_listing_cfts(prefix, suffix, amiid):
     f_ten_node.close()
 
 if __name__ == '__main__':
-    write_listing_cfts("QF2", "5TB", "AMI-ID-US-EAST-1")
-    write_listing_cfts("QF2", "20TB", "AMI-ID-US-EAST-1")
+    write_listing_cfts("QF2", "5TB", "AMI-ID-US-EAST-1") #to be replaced with real 5TB AMIID
+    write_listing_cfts("QF2", "20TB", "AMI-ID-US-EAST-1") #to be replaced with real 5TB AMIID
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Qumulo Cloud Deployment Samples
 Samples for deploying Qumulo Core in AWS using popular orchestration
-technologies.  Right now we have a sample template for Terraform, but please
-open an issue or PR and we'll add your favorite orchestration technology.
+technologies.  Right now we have a sample template for Terraform, and a script to generate a custom AWS CloudFormation template but please open an issue or PR and we'll add your favorite orchestration technology.
 
 ## Terraform
 www.terraform.io
@@ -13,6 +12,7 @@ environment.
 
 ## CloudFormation
 https://aws.amazon.com/cloudformation/
+
 `generate_qcft.py` contains a python script that generates an AWS CloudFormation
 template (CFT) with the desired number of nodes and instance names. The CFT that 
 is generated will contain a preconfigured AWS Security Group that enables the 


### PR DESCRIPTION
Now takes in an AMI ID for us-east-1 and produces 3 CFTs for our marketplace listings. The three templates are for 4, 6, and 10 node clusters.